### PR TITLE
Browsersync improvements

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -72,21 +72,24 @@ gulp.task('watch', function(){
  *
  * - same as 'gulp watch', only with live updating
  */
-gulp.task('browsersync', ['watch'], function() {
+gulp.task('serve', ['watch'], function() {
   // Connect to craft.dev via BrowserSync:
   plugins.browserSync.init({
-    proxy: serverName
+    proxy: serverName,
+    notify: false,
+    open: false,
+    proxy: serverName,
+    socket: {
+      domain: 'localhost:3000',
+    }
   });
 
-  // For scripts + templates, do a full page reload:
-  // (styles get refreshed on page because the 'style' task
-  // streams to Browsersync)
+  // For templates, do a full page reload:
+  // (styles + )
   gulp.watch([
-    path.src + '/**/*.*',
-    '!' + path.src + '/styles/**/*.scss',
     './app/craft/templates/**/*.twig'
   ])
-  .on('change', plugins.browserSync.reload);
+    .on('change', plugins.browserSync.reload);
 });
 
 /**
@@ -169,6 +172,7 @@ gulp.task('scripts', function(){
     .pipe(plugins.vinylSourceStream('bundle.js'))
     .pipe(plugins.vinylBuffer())
     .pipe(gulp.dest(path.dest + '/scripts'))
+    .pipe(plugins.browserSync.stream())
     .pipe(plugins.size({ showFiles: true }));
 });
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Be sure to follow these steps carefully if you want Crafty Vagrant to behave!
 
 ## Usage
 
-* `gulp browsersync` when you're ready to start developing: this will open a browser tab that will update live (via the magic of [Browsersync](https://www.browsersync.io/)) as you make changes to styles, templates, scripts, etc. If you don't want live updating, `gulp watch` will perform the same tasks (compiling Sass, etc) without the autorefresh.
+* `gulp serve` when you're ready to start developing. The page will autorefresh via the magic of [Browsersync](https://www.browsersync.io/)) ss you make changes to styles, templates, scripts, etc. If you don't want live updating, `gulp watch` will perform the same tasks (compiling Sass, etc) without the autorefresh.
 
 * If this is a fresh install of Craft, you may see error pages until you've installed it by visiting  [http://craft.dev/admin/install](http://craft.dev/admin/install)
 
@@ -45,7 +45,7 @@ If you want to work on Crafty Vagrant itself (ie. on the default config / starti
 
 2. Add the line `define('CRAFT_TEMPLATES_PATH', "../src/craft/templates");` to the top of Craft's `app/public/index.php` file. This lets you work directly on the source templates alongside a working installation of Craft.
 
-3. gitignore everything inside the `app` directory apart from `app/src` to prevent it being checked into Crafty Vagrant itself. ie. add the following lines to `.gitignore`: 
+3. gitignore everything inside the `app` directory apart from `app/src` to prevent it being checked into Crafty Vagrant itself. ie. add the following lines to `.gitignore`:
 
         app/*
         !app/src*

--- a/app/src/craft/templates/_layout.twig
+++ b/app/src/craft/templates/_layout.twig
@@ -79,5 +79,13 @@
   {% if not craft.request.isLivePreview %}
   {# Analytics script goes here... #}
   {% endif %}
+
+  {% if craft.config.devMode %}
+  <script id="__bs_script__">
+    //<![CDATA[
+      document.write("<script async src='http://localhost:3000/browser-sync/browser-sync-client.2.11.2.js'><\/script>");
+    //]]>
+  </script>
+  {% endif %}
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -99,12 +99,9 @@ fi
 
 echo_color "
 ## Finished!
- when you're ready to start developing: this will open a browser tab that will update live (via the magic of Browsersync) as you make changes to styles, templates, scripts, etc. If you don't want live updating, gulp watch will perform the same tasks (compiling Sass, etc) without the autorefresh.
-
-
 ##
 ## 'vagrant up' to start the server.
-## 'gulp browsersync' for live reloading in Sass/JS/Twig for changes.
+## 'gulp serve' for live reloading in Sass/JS/Twig for changes.
 ##    or
 ## 'gulp watch' compiles assets but without livereloading
 ##


### PR DESCRIPTION
Allow livereload via craft.dev domain, change task name to serve and inject JS changes as well