### PR TITLE
Add sourcemaps to Gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -125,6 +125,9 @@ gulp.task('images', function(){
  */
 gulp.task('styles', function(){
   gulp.src(path.src + '/styles/main.scss')
+    //Load sourcemaps
+    .pipe(plugins.sourcemaps.init())
+
     // Compile Sass:
     .pipe(plugins.sass.sync({
         includePaths: [
@@ -143,6 +146,9 @@ gulp.task('styles', function(){
         'ie 9'
       ]
     }))
+    //Complete sourcemaps
+    .pipe(plugins.sourcemaps.write())
+    
     // Write main.css
     .pipe(gulp.dest(path.dest + '/styles'))
     .pipe(plugins.browserSync.stream())


### PR DESCRIPTION
I noticed in the master branch sourcemaps are loaded in package.json but never used - I was working on my project and realized it was kinda annoying to debug without them, so added sourcemapping back in — takes just two lines but makes life a lot easier. 